### PR TITLE
Fix reset button to fully clear Good Project form

### DIFF
--- a/app/goodprojform/page.tsx
+++ b/app/goodprojform/page.tsx
@@ -18,7 +18,7 @@ export default function GoodProjFormPage() {
     watch,
     setValue,
   } = useForm<FormData>({
-    defaultValues,
+    defaultValues: structuredClone(defaultValues),
     resolver: zodResolver(FormSchema),
     mode: "onBlur",
   });
@@ -64,7 +64,7 @@ export default function GoodProjFormPage() {
   };
 
   const loadDemo = () => {
-    reset(demoData, { keepDefaultValues: true });
+    reset(structuredClone(demoData), { keepDefaultValues: true });
   };
 
   // For instant preview
@@ -657,7 +657,7 @@ export default function GoodProjFormPage() {
           <button type="button" className="btn" onClick={copyJson}>
             Copier JSON
           </button>
-          <button type="button" className="btn" onClick={() => reset(defaultValues)}>
+          <button type="button" className="btn" onClick={() => reset(structuredClone(defaultValues))}>
             Réinitialiser
           </button>
           <button type="button" className="btn" onClick={loadDemo}>


### PR DESCRIPTION
## Summary
- Deep clone form default values when initializing the Good Project form
- Clone demo data before loading to avoid mutating defaults
- Reset button now restores a fresh copy of default values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2b2660110832fb9a3c5b65cf36798